### PR TITLE
Fix HTTP requests with valid EOL

### DIFF
--- a/config.c
+++ b/config.c
@@ -550,7 +550,7 @@ void config_load(CONFIG *conf, int argc, char **argv) {
 				break;
 			case 'H':
 			case 'h':
-				show_usage(0);
+				show_usage();
 				exit(0);
 				break;
 		}

--- a/config.c
+++ b/config.c
@@ -413,6 +413,7 @@ static void show_usage() {
 	puts("Server settings:");
 	puts("\t-b addr\t\tLocal IP address to bind.   (default: 0.0.0.0)");
 	puts("\t-p port\t\tPort to listen.             (default: 0)");
+	puts("\t-N disable network");
 	puts("\t-d pidfile\tDaemonize with pidfile");
 	puts("\t-l host\t\tSyslog host                 (default: disabled)");
 	puts("\t-L port\t\tSyslog port                 (default: 514)");
@@ -454,8 +455,9 @@ void config_load(CONFIG *conf, int argc, char **argv) {
 	conf->logport = 514;
 	conf->server_port = 0;
 	conf->server_socket = -1;
+	conf->write_output_network = 1;
 
-	while ((j = getopt(argc, argv, "i:b:p:g:c:n:e:d:t:o:O:P:l:L:B:m:qDHhWE")) != -1) {
+	while ((j = getopt(argc, argv, "i:b:p:g:c:n:e:d:t:o:O:P:l:L:B:m:qDHhEWN")) != -1) {
 		switch (j) {
 			case 'i':
 				conf->ident = strdup(optarg);
@@ -530,6 +532,9 @@ void config_load(CONFIG *conf, int argc, char **argv) {
 					exit(1);
 				}
 				break;
+			case 'N':
+				conf->write_output_network = 0;
+				break;
 			case 'W':
 				conf->write_output_file = 1;
 				output_open_file(conf->output);
@@ -579,7 +584,7 @@ void config_load(CONFIG *conf, int argc, char **argv) {
 	conf->output_bitrate         = conf->output_packets_per_sec * (1316 * 8);
 	conf->output_tmout           = 1000000 / conf->output_packets_per_sec;
 
-	if (conf->server_port)
+	if (conf->write_output_network && conf->server_port)
 		init_server_socket(conf->server_addr, conf->server_port, &conf->server, &conf->server_socket);
 
 	if (!conf->quiet) {

--- a/config.c
+++ b/config.c
@@ -555,7 +555,7 @@ void config_load(CONFIG *conf, int argc, char **argv) {
 				break;
 		}
 	}
-	if (!conf->output->out_host.s_addr) {
+	if (conf->write_output_network && !conf->output->out_host.s_addr) {
 		fprintf(stderr, "ERROR: Output address is not set (use -O x.x.x.x)\n");
 		show_usage();
 		goto ERR;
@@ -584,7 +584,7 @@ void config_load(CONFIG *conf, int argc, char **argv) {
 	conf->output_bitrate         = conf->output_packets_per_sec * (1316 * 8);
 	conf->output_tmout           = 1000000 / conf->output_packets_per_sec;
 
-	if (conf->write_output_network && conf->server_port)
+	if (conf->server_port)
 		init_server_socket(conf->server_addr, conf->server_port, &conf->server, &conf->server_socket);
 
 	if (!conf->quiet) {

--- a/config.c
+++ b/config.c
@@ -457,7 +457,7 @@ void config_load(CONFIG *conf, int argc, char **argv) {
 	conf->server_socket = -1;
 	conf->write_output_network = 1;
 
-	while ((j = getopt(argc, argv, "i:b:p:g:c:n:e:d:t:o:O:P:l:L:B:m:qDHhEWN")) != -1) {
+	while ((j = getopt(argc, argv, "i:b:p:g:c:n:e:d:t:o:O:P:l:L:B:m:W:qDHhEN")) != -1) {
 		switch (j) {
 			case 'i':
 				conf->ident = strdup(optarg);
@@ -537,7 +537,7 @@ void config_load(CONFIG *conf, int argc, char **argv) {
 				break;
 			case 'W':
 				conf->write_output_file = 1;
-				output_open_file(conf->output);
+				output_open_file(optarg, conf->output);
 				break;
 			case 'E':
 				conf->write_input_file = 1;

--- a/config.h
+++ b/config.h
@@ -53,6 +53,7 @@ typedef struct {
 	int				quiet;
 
 	int				write_input_file;
+	int				write_output_network;
 	int				write_output_file;
 	int				pcr_mode;			// 0 - do not touch PCRs
 										// 1 - move PCRs to their calculated place

--- a/data.c
+++ b/data.c
@@ -287,7 +287,12 @@ OUTPUT *output_new() {
 }
 
 void output_open_file(char *filename, OUTPUT *o) {
-	o->ofd = open(filename, O_CREAT | O_WRONLY | O_TRUNC, 0644);
+	int fd = open(filename, O_CREAT | O_WRONLY | O_TRUNC, 0660);
+	if (fd == -1) {
+		perror("Cannot open output file\n");
+		exit(1);
+	}
+	o->ofd = fd;
 }
 
 void obuf_reset(OBUF *ob) {

--- a/data.c
+++ b/data.c
@@ -286,8 +286,8 @@ OUTPUT *output_new() {
 	return o;
 }
 
-void output_open_file(OUTPUT *o) {
-	o->ofd = open("mptsd-output.ts", O_CREAT | O_WRONLY | O_TRUNC, 0644);
+void output_open_file(char *filename, OUTPUT *o) {
+	o->ofd = open(filename, O_CREAT | O_WRONLY | O_TRUNC, 0644);
 }
 
 void obuf_reset(OBUF *ob) {

--- a/data.h
+++ b/data.h
@@ -239,7 +239,7 @@ void		input_stream_reset	(INPUT *input);
 
 OUTPUT *	output_new			();
 void		output_free			(OUTPUT **output);
-void		output_open_file	(OUTPUT *o);
+void		output_open_file	(char *filename, OUTPUT *o);
 void		output_buffer_alloc	(OUTPUT *o, double output_bitrate);
 void		obuf_reset			(OBUF *ob);
 

--- a/mptsd.c
+++ b/mptsd.c
@@ -157,7 +157,7 @@ int main(int argc, char **argv) {
 	daemonize(config->pidfile);
 	web_server_start(config);
 	log_init(config->logident, config->syslog_active, config->pidfile == NULL, config->loghost, config->logport);
-	init_signals(config);
+	init_signals();
 
 	LOGf("INIT  : %s %s (%s)\n" , server_sig, server_ver, config->ident);
 

--- a/network.c
+++ b/network.c
@@ -153,7 +153,7 @@ int connect_source(INPUT *r, int retries, int readbuflen, int *http_code) {
 			DO_RECONNECT;
 		}
 
-		snprintf(buf,sizeof(buf)-1, "GET /%s HTTP/1.0\nHost: %s:%u\nX-Smart-Client: yes\nUser-Agent: %s %s (%s)\n\n",
+		snprintf(buf,sizeof(buf)-1, "GET /%s HTTP/1.0\r\nHost: %s:%u\r\nX-Smart-Client: yes\r\nUser-Agent: %s %s (%s)\r\n\r\n",
 		         src->path, src->host, src->port, server_sig, server_ver, config->ident);
 		buf[sizeof(buf)-1] = 0;
 		fdwrite(r->sock, buf, strlen(buf));

--- a/network.c
+++ b/network.c
@@ -170,7 +170,7 @@ int connect_source(INPUT *r, int retries, int readbuflen, int *http_code) {
 				regcomp(&http_response, "^HTTP/1.[0-1] (([0-9]{3}) .*)", REG_EXTENDED);
 				if (regexec(&http_response,buf,3,res,0) != REG_NOMATCH) {
 					char codestr[4];
-					if ((unsigned int)res[1].rm_eo-res[1].rm_so < sizeof(xresponse)) {
+					if ((unsigned long)res[1].rm_eo-res[1].rm_so < sizeof(xresponse)) {
 						strncpy(xresponse, &buf[res[1].rm_so], res[1].rm_eo-res[1].rm_so);
 						xresponse[res[1].rm_eo-res[1].rm_so] = '\0';
 						chomp(xresponse);

--- a/output_write.c
+++ b/output_write.c
@@ -217,7 +217,7 @@ void * output_handle_write(void *_config) {
 		if (written < 0) {
 			LOG("OUTPUT: Error writing into output socket.\n");
 			shutdown_fd(&o->out_sock);
-			if (config->write_output_network) {
+			if (conf->write_output_network) {
 				connect_output(o);
 			}
 		}

--- a/output_write.c
+++ b/output_write.c
@@ -217,7 +217,9 @@ void * output_handle_write(void *_config) {
 		if (written < 0) {
 			LOG("OUTPUT: Error writing into output socket.\n");
 			shutdown_fd(&o->out_sock);
-			connect_output(o);
+			if (config->write_output_network) {
+				connect_output(o);
+			}
 		}
 	}
 OUT:


### PR DESCRIPTION
Some HTTP servers don't work when you not use the correct CR LF end-of-line marker in the request.
CRLF ("\r\n") follows RFC2616.
This patch fixes it.